### PR TITLE
Make Endpoint.sendBulkTransfer not use inout on the data parameter

### DIFF
--- a/Sources/SwiftLibUSB/LibUSBWrapper/Endpoint.swift
+++ b/Sources/SwiftLibUSB/LibUSBWrapper/Endpoint.swift
@@ -153,7 +153,7 @@ public class Endpoint {
     /// - Parameters:
     ///   - data: the raw bytes to send unaltered to the device through this endpoint
     ///   - timeout: The time, in millisecounds, to wait before timeout. This is by default one second
-    public func sendBulkTransfer(data: inout Data, timeout: Int = 1000) throws -> Int {
+    public func sendBulkTransfer(data: Data, timeout: Int = 1000) throws -> Int {
         // Only work if we are the right kind of endpoint
         if transferType != .bulk || direction != .out {
             throw USBError.notSupported

--- a/Sources/SwiftLibUSB/USBTMCInstrument.swift
+++ b/Sources/SwiftLibUSB/USBTMCInstrument.swift
@@ -249,7 +249,7 @@ extension USBTMCInstrument {
             
             // Send the request message to a bulk out endpoint
             let bytesSent = try outEndpoint.sendBulkTransfer(
-                data: &message,
+                data: message,
                 timeout: Int(attributes.operationDelay * 1000))
             
             // Throw if not all bytes were sent
@@ -414,7 +414,7 @@ extension USBTMCInstrument: MessageBasedInstrument {
             dataToSend.append(Data(Array(repeating: 0, count: paddingLength)))
             
             let numSent = try outEndpoint.sendBulkTransfer(
-                data: &dataToSend,
+                data: dataToSend,
                 timeout: Int(attributes.operationDelay * 1000))
             
             lowerBound += numSent - Self.headerSize - paddingLength // Move up by the amount sent


### PR DESCRIPTION
This was originally used so we could use unsafeMutableBytes, but since we convert it to an array anyway, it just made example code harder.